### PR TITLE
chore: replace vue-signal by ref

### DIFF
--- a/vue-example-plugin/package.json
+++ b/vue-example-plugin/package.json
@@ -14,7 +14,6 @@
     "@penpot/plugin-styles": "^0.8.0",
     "@penpot/plugin-types": "^1.0.0",
     "vue": "^3.4.21",
-    "vue-signals": "^0.3.1"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.8.0",

--- a/vue-example-plugin/package.json
+++ b/vue-example-plugin/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@penpot/plugin-styles": "^0.8.0",
     "@penpot/plugin-types": "^1.0.0",
-    "vue": "^3.4.21",
+    "vue": "^3.4.21"
   },
   "devDependencies": {
     "@rushstack/eslint-patch": "^1.8.0",

--- a/vue-example-plugin/src/App.vue
+++ b/vue-example-plugin/src/App.vue
@@ -1,26 +1,25 @@
 <script setup lang="ts">
-import { onMounted } from 'vue';
-import { signal } from 'vue-signals';
+import { onMounted, ref } from "vue";
 
-const theme = signal<string | null>(null);
+const theme = ref<string | null>(null);
 
 onMounted(() => {
   const url = new URL(window.location.href);
 
-  const initialTheme = url.searchParams.get('theme');
+  const initialTheme = url.searchParams.get("theme");
 
   if (initialTheme) {
-    theme.set(initialTheme as string);
+    theme.value = initialTheme as string;
   }
 
-  window.addEventListener('message', (event) => {
-    if (event.data.type === 'theme') {
-      theme.set(event.data.content);
+  window.addEventListener("message", (event) => {
+    if (event.data.type === "theme") {
+      theme.value = event.data.content;
     }
   });
 });
 </script>
 
 <template>
-  <main :data-theme="theme()">Welcome to your plugin!</main>
+  <main :data-theme="theme">Welcome to your plugin!</main>
 </template>


### PR DESCRIPTION
Hello !

I'm introducing this change beacause of the fact that signals aren't native to Vue.js, and might not be the best fit for the use case. Additionally, npm raised a memory leak warning related to the vue-signal package.

As a solution, I've suggested replacing signals with refs, which are more appropriate in the context of Vue 3 applications.